### PR TITLE
コンパイラを実装

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,158 @@
+use std::fmt::Write as _;
+
+use crate::parser::Node;
+
+mod decl;
+mod emit;
+mod parallel;
+
+pub const TAPE_LEN: i64 = 30_000;
+pub const MUTEX_STRIDE: i64 = 64; // pthread_mutex_t のサイズが不明なので余裕を確保
+pub const LOCK_STACK_INIT: i64 = 16;
+
+pub fn generate_ir(nodes: &[Node]) -> String {
+    let mut cg = Codegen::new();
+    cg.preamble(); // globals, %State, declare群, ランタイム関数定義
+    cg.define_thunk("main", nodes); // @thunk_main(%State*) を定義（本体は命令関数呼び出し）
+    cg.define_main(); // @main 初期化 → @thunk_main → 0で終了
+    cg.finish()
+}
+
+pub struct Codegen {
+    out: String,
+    indent: usize,
+    pub uniq: usize,
+}
+
+impl Codegen {
+    fn new() -> Self {
+        let mut this = Self {
+            out: String::with_capacity(32 * 1024),
+            indent: 0,
+            uniq: 0,
+        };
+        this
+    }
+
+    pub fn finish(self) -> String {
+        self.out
+    }
+
+    fn wln(&mut self, s: &str) {
+        for _ in 0..self.indent {
+            self.out.push_str("  ");
+        }
+        let _ = writeln!(self.out, "{s}");
+    }
+    pub fn label(&mut self, name: &str) {
+        let _ = writeln!(self.out, "{name}:");
+    }
+    pub fn fresh(&mut self, prefix: &str) -> String {
+        let id = self.uniq;
+        self.uniq += 1;
+        format!("%{prefix}{id}")
+    }
+
+    fn preamble(&mut self) {
+        // 共有テープと mutex スロットのスラブ（実体アドレスは起動時に確保）
+        self.wln(&format!(
+            "@tape = internal global [{TAPE_LEN} x i8] zeroinitializer"
+        ));
+        self.wln("@mutex_slab = internal global i8* null");
+        self.wln(
+            "%State = type { i8*, i64, i8*, i64*, i64, i64 } ; (tape, ptr, slab, stack, sp, cap)",
+        );
+        self.wln("");
+
+        decl::decl_externals(self);
+        decl::define_runtime_helpers(self); // push/pop, bf_* 命令など
+        self.wln("");
+    }
+
+    fn define_main(&mut self) {
+        self.wln("define i32 @main() {");
+        self.indent += 1;
+        self.label("entry");
+
+        // mutex_slab を確保 & 初期化
+        self.wln(&format!("%slab_bytes = mul i64 {TAPE_LEN}, {MUTEX_STRIDE}"));
+        self.wln("%slab = call i8* @malloc(i64 %slab_bytes)");
+        self.wln("store i8* %slab, i8** @mutex_slab");
+
+        // 全セル分の pthread_mutex_init
+        self.wln("%i = alloca i64");
+        self.wln("store i64 0, i64* %i");
+        self.label("init.loop");
+        self.wln(&format!("%cur = load i64, i64* %i"));
+        self.wln(&format!("%cond = icmp slt i64 %cur, {TAPE_LEN}"));
+        self.wln("br i1 %cond, label %init.body, label %init.end");
+
+        self.label("init.body");
+        self.wln("%sl0 = load i8*, i8** @mutex_slab");
+        self.wln(&format!("%off = mul i64 %cur, {MUTEX_STRIDE}"));
+        self.wln("%slot = getelementptr i8, i8* %sl0, i64 %off");
+        self.wln("call i32 @pthread_mutex_init(i8* %slot, i8* null)");
+        self.wln("%cur1 = add i64 %cur, 1");
+        self.wln("store i64 %cur1, i64* %i");
+        self.wln("br label %init.loop");
+
+        self.label("init.end");
+
+        // 初期 State を確保・初期化
+        self.wln(
+            "%st_bytes = ptrtoint (%State* getelementptr(%State, %State* null, i32 1) to i64)",
+        ); // 定数式 GEP はこのまま
+        self.wln("%st = call i8* @malloc(i64 %st_bytes)");
+        self.wln("%S = bitcast i8* %st to %State*");
+        self.wln(&format!(
+            "%base = getelementptr [{TAPE_LEN} x i8], [{TAPE_LEN} x i8]* @tape, i64 0, i64 0"
+        ));
+        // store i8* %base -> field 0
+        let f0 = self.fresh("fld");
+        self.wln(&format!("{f0} = getelementptr %State, %State* %S, i32 0, i32 0"));
+        self.wln(&format!("store i8* %base, i8** {f0}"));
+        // ptr index 0
+        let f1 = self.fresh("fld");
+        self.wln(&format!("{f1} = getelementptr %State, %State* %S, i32 0, i32 1"));
+        self.wln(&format!("store i64 0, i64* {f1}"));
+        // mutex slab
+        self.wln("%sl = load i8*, i8** @mutex_slab");
+        let f2 = self.fresh("fld");
+        self.wln(&format!("{f2} = getelementptr %State, %State* %S, i32 0, i32 2"));
+        self.wln(&format!("store i8* %sl, i8** {f2}"));
+
+        // ロックスタック base, sp=0, cap
+        self.wln(&format!("%lsz = mul i64 {LOCK_STACK_INIT}, 8"));
+        self.wln("%stk = call i8* @malloc(i64 %lsz)");
+        self.wln("%stk64 = bitcast i8* %stk to i64*");
+        let f3 = self.fresh("fld");
+        self.wln(&format!("{f3} = getelementptr %State, %State* %S, i32 0, i32 3"));
+        self.wln(&format!("store i64* %stk64, i64** {f3}"));
+        let f4 = self.fresh("fld");
+        self.wln(&format!("{f4} = getelementptr %State, %State* %S, i32 0, i32 4"));
+        self.wln(&format!("store i64 0, i64* {f4}"));
+        let f5 = self.fresh("fld");
+        self.wln(&format!("{f5} = getelementptr %State, %State* %S, i32 0, i32 5"));
+        self.wln(&format!("store i64 {LOCK_STACK_INIT}, i64* {f5}"));
+
+        // トップレベル実行
+        self.wln("call void @thunk_main(%State* %S)");
+        self.wln("ret i32 0");
+        self.indent -= 1;
+        self.wln("}");
+    }
+
+    /// 任意のノード列から thunk を作る（並列ブロックの各枝用にも再利用）
+    pub fn define_thunk(&mut self, name: &str, nodes: &[Node]) {
+        self.wln(&format!(
+            "define internal void @thunk_{name}(%State* nocapture nonnull %S) {{"
+        ));
+        self.indent += 1;
+        self.label("entry");
+        emit::emit_nodes(self, "%S", nodes);
+        self.wln("ret void");
+        self.indent -= 1;
+        self.wln("}");
+        self.wln("");
+    }
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -13,8 +13,9 @@ pub const LOCK_STACK_INIT: i64 = 16;
 pub fn generate_ir(nodes: &[Node]) -> String {
     let mut cg = Codegen::new();
     cg.preamble(); // globals, %State, declare群, ランタイム関数定義
-    cg.define_thunk("main", nodes); // @thunk_main(%State*) を定義（本体は命令関数呼び出し）
-    cg.define_main(); // @main 初期化 → @thunk_main → 0で終了
+    cg.defer_thunk("main", nodes); // main 用 thunk を遅延定義
+    cg.define_main(); // @main 初期化 → @thunk_main 呼び出し
+    cg.flush_deferred(); // 末尾に全遅延関数を出力
     cg.finish()
 }
 
@@ -22,14 +23,16 @@ pub struct Codegen {
     out: String,
     indent: usize,
     pub uniq: usize,
+    deferred: Vec<String>, // 遅延する関数定義
 }
 
 impl Codegen {
     fn new() -> Self {
-        let mut this = Self {
+        let this = Self {
             out: String::with_capacity(32 * 1024),
             indent: 0,
             uniq: 0,
+            deferred: Vec::new(),
         };
         this
     }
@@ -53,6 +56,63 @@ impl Codegen {
         format!("%{prefix}{id}")
     }
 
+    fn push_def(&mut self, def: String) {
+        self.deferred.push(def);
+    }
+    fn flush_deferred(&mut self) {
+        for def in std::mem::take(&mut self.deferred) {
+            self.out.push_str(&def);
+        }
+    }
+
+    fn with_temp_buffer<F: FnOnce(&mut Self)>(&mut self, f: F) -> String {
+        // swap out current buffer & indent
+        let mut saved_out = String::new();
+        std::mem::swap(&mut self.out, &mut saved_out);
+        let saved_indent = self.indent;
+        self.indent = 0;
+        f(self);
+        let produced = std::mem::take(&mut self.out);
+        // restore
+        self.out = saved_out;
+        self.indent = saved_indent;
+        produced
+    }
+
+    /// 任意のノード列から thunk を作成し遅延出力
+    pub fn defer_thunk(&mut self, name: &str, nodes: &[Node]) {
+        let ir = self.with_temp_buffer(|this| {
+            this.wln(&format!(
+                "define internal void @thunk_{name}(%State* nocapture nonnull %S) {{"
+            ));
+            this.indent += 1;
+            this.label("entry");
+            emit::emit_nodes(this, "%S", nodes);
+            this.wln("ret void");
+            this.indent -= 1;
+            this.wln("}");
+            this.wln("");
+        });
+        self.push_def(ir);
+    }
+
+    /// thread_start_* ラッパー関数を遅延生成
+    pub fn defer_thread_start(&mut self, tname: &str) {
+        let ir = self.with_temp_buffer(|this| {
+            this.wln(&format!(
+                "define internal i8* @thread_start_{tname}(i8* %arg) nounwind {{"
+            ));
+            this.indent += 1;
+            this.wln("%S = bitcast i8* %arg to %State*");
+            this.wln(&format!("call void @thunk_{tname}(%State* %S)"));
+            this.wln("ret i8* null");
+            this.indent -= 1;
+            this.wln("}");
+            this.wln("");
+        });
+        self.push_def(ir);
+    }
+
     fn preamble(&mut self) {
         // 共有テープと mutex スロットのスラブ（実体アドレスは起動時に確保）
         self.wln(&format!(
@@ -63,7 +123,6 @@ impl Codegen {
             "%State = type { i8*, i64, i8*, i64*, i64, i64 } ; (tape, ptr, slab, stack, sp, cap)",
         );
         self.wln("");
-
         decl::decl_externals(self);
         decl::define_runtime_helpers(self); // push/pop, bf_* 命令など
         self.wln("");
@@ -73,12 +132,10 @@ impl Codegen {
         self.wln("define i32 @main() {");
         self.indent += 1;
         self.label("entry");
-
         // mutex_slab を確保 & 初期化
         self.wln(&format!("%slab_bytes = mul i64 {TAPE_LEN}, {MUTEX_STRIDE}"));
         self.wln("%slab = call i8* @malloc(i64 %slab_bytes)");
         self.wln("store i8* %slab, i8** @mutex_slab");
-
         // 全セル分の pthread_mutex_init
         self.wln("%i = alloca i64");
         self.wln("store i64 0, i64* %i");
@@ -86,7 +143,6 @@ impl Codegen {
         self.wln(&format!("%cur = load i64, i64* %i"));
         self.wln(&format!("%cond = icmp slt i64 %cur, {TAPE_LEN}"));
         self.wln("br i1 %cond, label %init.body, label %init.end");
-
         self.label("init.body");
         self.wln("%sl0 = load i8*, i8** @mutex_slab");
         self.wln(&format!("%off = mul i64 %cur, {MUTEX_STRIDE}"));
@@ -95,9 +151,7 @@ impl Codegen {
         self.wln("%cur1 = add i64 %cur, 1");
         self.wln("store i64 %cur1, i64* %i");
         self.wln("br label %init.loop");
-
         self.label("init.end");
-
         // 初期 State を確保・初期化
         self.wln(
             "%st_bytes = ptrtoint (%State* getelementptr(%State, %State* null, i32 1) to i64)",
@@ -107,52 +161,44 @@ impl Codegen {
         self.wln(&format!(
             "%base = getelementptr [{TAPE_LEN} x i8], [{TAPE_LEN} x i8]* @tape, i64 0, i64 0"
         ));
-        // store i8* %base -> field 0
         let f0 = self.fresh("fld");
-        self.wln(&format!("{f0} = getelementptr %State, %State* %S, i32 0, i32 0"));
+        self.wln(&format!(
+            "{f0} = getelementptr %State, %State* %S, i32 0, i32 0"
+        ));
         self.wln(&format!("store i8* %base, i8** {f0}"));
-        // ptr index 0
         let f1 = self.fresh("fld");
-        self.wln(&format!("{f1} = getelementptr %State, %State* %S, i32 0, i32 1"));
+        self.wln(&format!(
+            "{f1} = getelementptr %State, %State* %S, i32 0, i32 1"
+        ));
         self.wln(&format!("store i64 0, i64* {f1}"));
-        // mutex slab
         self.wln("%sl = load i8*, i8** @mutex_slab");
         let f2 = self.fresh("fld");
-        self.wln(&format!("{f2} = getelementptr %State, %State* %S, i32 0, i32 2"));
+        self.wln(&format!(
+            "{f2} = getelementptr %State, %State* %S, i32 0, i32 2"
+        ));
         self.wln(&format!("store i8* %sl, i8** {f2}"));
-
-        // ロックスタック base, sp=0, cap
         self.wln(&format!("%lsz = mul i64 {LOCK_STACK_INIT}, 8"));
         self.wln("%stk = call i8* @malloc(i64 %lsz)");
         self.wln("%stk64 = bitcast i8* %stk to i64*");
         let f3 = self.fresh("fld");
-        self.wln(&format!("{f3} = getelementptr %State, %State* %S, i32 0, i32 3"));
+        self.wln(&format!(
+            "{f3} = getelementptr %State, %State* %S, i32 0, i32 3"
+        ));
         self.wln(&format!("store i64* %stk64, i64** {f3}"));
         let f4 = self.fresh("fld");
-        self.wln(&format!("{f4} = getelementptr %State, %State* %S, i32 0, i32 4"));
+        self.wln(&format!(
+            "{f4} = getelementptr %State, %State* %S, i32 0, i32 4"
+        ));
         self.wln(&format!("store i64 0, i64* {f4}"));
         let f5 = self.fresh("fld");
-        self.wln(&format!("{f5} = getelementptr %State, %State* %S, i32 0, i32 5"));
+        self.wln(&format!(
+            "{f5} = getelementptr %State, %State* %S, i32 0, i32 5"
+        ));
         self.wln(&format!("store i64 {LOCK_STACK_INIT}, i64* {f5}"));
-
         // トップレベル実行
         self.wln("call void @thunk_main(%State* %S)");
         self.wln("ret i32 0");
         self.indent -= 1;
         self.wln("}");
-    }
-
-    /// 任意のノード列から thunk を作る（並列ブロックの各枝用にも再利用）
-    pub fn define_thunk(&mut self, name: &str, nodes: &[Node]) {
-        self.wln(&format!(
-            "define internal void @thunk_{name}(%State* nocapture nonnull %S) {{"
-        ));
-        self.indent += 1;
-        self.label("entry");
-        emit::emit_nodes(self, "%S", nodes);
-        self.wln("ret void");
-        self.indent -= 1;
-        self.wln("}");
-        self.wln("");
     }
 }

--- a/src/codegen/decl.rs
+++ b/src/codegen/decl.rs
@@ -1,172 +1,172 @@
 use super::{Codegen, MUTEX_STRIDE};
 
 pub fn decl_externals(g: &mut Codegen) {
-    g.wln("declare i32 @putchar(i32)");
-    g.wln("declare i32 @getchar()");
-    g.wln("declare i32 @usleep(i32)");
-    g.wln("declare i8* @malloc(i64)");
-    g.wln("declare void @free(i8*)");
-    g.wln("declare i32 @pthread_create(i64*, i8*, i8* (i8*)*, i8*)");
-    g.wln("declare i32 @pthread_join(i64, i8**)");
-    g.wln("declare i32 @pthread_mutex_init(i8*, i8*)");
-    g.wln("declare i32 @pthread_mutex_lock(i8*)");
-    g.wln("declare i32 @pthread_mutex_unlock(i8*)");
+    g.line("declare i32 @putchar(i32)");
+    g.line("declare i32 @getchar()");
+    g.line("declare i32 @usleep(i32)");
+    g.line("declare i8* @malloc(i64)");
+    g.line("declare void @free(i8*)");
+    g.line("declare i32 @pthread_create(i64*, i8*, i8* (i8*)*, i8*)");
+    g.line("declare i32 @pthread_join(i64, i8**)");
+    g.line("declare i32 @pthread_mutex_init(i8*, i8*)");
+    g.line("declare i32 @pthread_mutex_lock(i8*)");
+    g.line("declare i32 @pthread_mutex_unlock(i8*)");
     // memcpy intrinsic (used for expanding the lock stack)
-    g.wln("declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1 immarg)");
+    g.line("declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1 immarg)");
 }
 
 pub fn define_runtime_helpers(g: &mut Codegen) {
     // GEP: pointer to current cell
-    g.wln("define internal i8* @bf_gep_cell_ptr(%State* nocapture nonnull %S) alwaysinline nounwind {");
+    g.line("define internal i8* @bf_gep_cell_ptr(%State* nocapture nonnull %S) alwaysinline nounwind {");
     g.indent += 1;
-    g.wln("%fld_base = getelementptr %State, %State* %S, i32 0, i32 0");
-    g.wln("%base = load i8*, i8** %fld_base");
-    g.wln("%fld_idx = getelementptr %State, %State* %S, i32 0, i32 1");
-    g.wln("%idx  = load i64,  i64*  %fld_idx");
-    g.wln("%p    = getelementptr i8, i8* %base, i64 %idx");
-    g.wln("ret i8* %p");
+    g.line("%fld_base = getelementptr %State, %State* %S, i32 0, i32 0");
+    g.line("%base = load i8*, i8** %fld_base");
+    g.line("%fld_idx = getelementptr %State, %State* %S, i32 0, i32 1");
+    g.line("%idx  = load i64,  i64*  %fld_idx");
+    g.line("%p    = getelementptr i8, i8* %base, i64 %idx");
+    g.line("ret i8* %p");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Address of lock slot (mutex_slab + idx * stride)
-    g.wln("define internal i8* @bf_lock_slot_addr(%State* nocapture nonnull %S, i64 %idx) alwaysinline nounwind {");
+    g.line("define internal i8* @bf_lock_slot_addr(%State* nocapture nonnull %S, i64 %idx) alwaysinline nounwind {");
     g.indent += 1;
-    g.wln("%fld_slab = getelementptr %State, %State* %S, i32 0, i32 2");
-    g.wln("%slab = load i8*, i8** %fld_slab");
-    g.wln(&format!("%off  = mul i64 %idx, {MUTEX_STRIDE}"));
-    g.wln("%slot = getelementptr i8, i8* %slab, i64 %off");
-    g.wln("ret i8* %slot");
+    g.line("%fld_slab = getelementptr %State, %State* %S, i32 0, i32 2");
+    g.line("%slab = load i8*, i8** %fld_slab");
+    g.line(&format!("%off  = mul i64 %idx, {MUTEX_STRIDE}"));
+    g.line("%slot = getelementptr i8, i8* %slab, i64 %off");
+    g.line("ret i8* %slot");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // push_lock(%S, idx) with dynamic growth
-    g.wln("define internal void @push_lock(%State* nocapture nonnull %S, i64 %idx) nounwind {");
+    g.line("define internal void @push_lock(%State* nocapture nonnull %S, i64 %idx) nounwind {");
     g.indent += 1;
-    g.wln("%fld_sp = getelementptr %State, %State* %S, i32 0, i32 4");
-    g.wln("%sp  = load i64,  i64*  %fld_sp");
-    g.wln("%fld_cap = getelementptr %State, %State* %S, i32 0, i32 5");
-    g.wln("%cap = load i64,  i64*  %fld_cap");
+    g.line("%fld_sp = getelementptr %State, %State* %S, i32 0, i32 4");
+    g.line("%sp  = load i64,  i64*  %fld_sp");
+    g.line("%fld_cap = getelementptr %State, %State* %S, i32 0, i32 5");
+    g.line("%cap = load i64,  i64*  %fld_cap");
     // Precompute fld_buf before branch for dominance
-    g.wln("%fld_buf = getelementptr %State, %State* %S, i32 0, i32 3");
-    g.wln("%need_grow = icmp eq i64 %sp, %cap");
-    g.wln("br i1 %need_grow, label %grow, label %push");
+    g.line("%fld_buf = getelementptr %State, %State* %S, i32 0, i32 3");
+    g.line("%need_grow = icmp eq i64 %sp, %cap");
+    g.line("br i1 %need_grow, label %grow, label %push");
 
-    g.wln("grow:");
-    g.wln("%oldbuf = load i64*, i64** %fld_buf");
-    g.wln("%oldcap = load i64, i64* %fld_cap");
-    g.wln("%newcap = shl i64 %oldcap, 1");
-    g.wln("%oldbytes = mul i64 %oldcap, 8");
-    g.wln("%newbytes = mul i64 %newcap, 8");
-    g.wln("%newraw = call i8* @malloc(i64 %newbytes)");
-    g.wln("%newbuf = bitcast i8* %newraw to i64*");
-    g.wln("%dst = bitcast i64* %newbuf to i8*");
-    g.wln("%src = bitcast i64* %oldbuf to i8*");
-    g.wln("call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 %oldbytes, i1 false)");
-    g.wln("call void @free(i8* %src)");
-    g.wln("store i64* %newbuf, i64** %fld_buf");
-    g.wln("store i64  %newcap, i64*  %fld_cap");
-    g.wln("br label %push");
+    g.line("grow:");
+    g.line("%oldbuf = load i64*, i64** %fld_buf");
+    g.line("%oldcap = load i64, i64* %fld_cap");
+    g.line("%newcap = shl i64 %oldcap, 1");
+    g.line("%oldbytes = mul i64 %oldcap, 8");
+    g.line("%newbytes = mul i64 %newcap, 8");
+    g.line("%newraw = call i8* @malloc(i64 %newbytes)");
+    g.line("%newbuf = bitcast i8* %newraw to i64*");
+    g.line("%dst = bitcast i64* %newbuf to i8*");
+    g.line("%src = bitcast i64* %oldbuf to i8*");
+    g.line("call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 %oldbytes, i1 false)");
+    g.line("call void @free(i8* %src)");
+    g.line("store i64* %newbuf, i64** %fld_buf");
+    g.line("store i64  %newcap, i64*  %fld_cap");
+    g.line("br label %push");
 
-    g.wln("push:");
-    g.wln("%buf = load i64*, i64** %fld_buf");
-    g.wln("%slotp = getelementptr i64, i64* %buf, i64 %sp");
-    g.wln("store i64 %idx, i64* %slotp");
-    g.wln("%sp1 = add i64 %sp, 1");
-    g.wln("store i64 %sp1, i64* %fld_sp");
-    g.wln("ret void");
+    g.line("push:");
+    g.line("%buf = load i64*, i64** %fld_buf");
+    g.line("%slotp = getelementptr i64, i64* %buf, i64 %sp");
+    g.line("store i64 %idx, i64* %slotp");
+    g.line("%sp1 = add i64 %sp, 1");
+    g.line("store i64 %sp1, i64* %fld_sp");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // pop_lock(%S) -> i64 (caller assumes non-empty stack)
-    g.wln("define internal i64 @pop_lock(%State* nocapture nonnull %S) nounwind {");
+    g.line("define internal i64 @pop_lock(%State* nocapture nonnull %S) nounwind {");
     g.indent += 1;
-    g.wln("%fld_sp2 = getelementptr %State, %State* %S, i32 0, i32 4");
-    g.wln("%sp  = load i64, i64* %fld_sp2");
-    g.wln("%sp1 = add i64 %sp, -1");
-    g.wln("store i64 %sp1, i64* %fld_sp2");
-    g.wln("%fld_buf2 = getelementptr %State, %State* %S, i32 0, i32 3");
-    g.wln("%buf = load i64*, i64** %fld_buf2");
-    g.wln("%slotp = getelementptr i64, i64* %buf, i64 %sp1");
-    g.wln("%idx = load i64, i64* %slotp");
-    g.wln("ret i64 %idx");
+    g.line("%fld_sp2 = getelementptr %State, %State* %S, i32 0, i32 4");
+    g.line("%sp  = load i64, i64* %fld_sp2");
+    g.line("%sp1 = add i64 %sp, -1");
+    g.line("store i64 %sp1, i64* %fld_sp2");
+    g.line("%fld_buf2 = getelementptr %State, %State* %S, i32 0, i32 3");
+    g.line("%buf = load i64*, i64** %fld_buf2");
+    g.line("%slotp = getelementptr i64, i64* %buf, i64 %sp1");
+    g.line("%idx = load i64, i64* %slotp");
+    g.line("ret i64 %idx");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Primitive: pointer movement
-    g.wln("define internal void @bf_inc_ptr(%State* nocapture nonnull %S, i64 %delta) alwaysinline nounwind {");
+    g.line("define internal void @bf_inc_ptr(%State* nocapture nonnull %S, i64 %delta) alwaysinline nounwind {");
     g.indent += 1;
-    g.wln("%fld_ptr = getelementptr %State,%State* %S, i32 0, i32 1");
-    g.wln("%v = load i64, i64* %fld_ptr");
-    g.wln("%u = add i64 %v, %delta");
-    g.wln("store i64 %u, i64* %fld_ptr");
-    g.wln("ret void");
+    g.line("%fld_ptr = getelementptr %State,%State* %S, i32 0, i32 1");
+    g.line("%v = load i64, i64* %fld_ptr");
+    g.line("%u = add i64 %v, %delta");
+    g.line("store i64 %u, i64* %fld_ptr");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Primitive: add to cell (non-atomic)
-    g.wln("define internal void @bf_add_cell(%State* nocapture nonnull %S, i32 %delta) alwaysinline nounwind {");
+    g.line("define internal void @bf_add_cell(%State* nocapture nonnull %S, i32 %delta) alwaysinline nounwind {");
     g.indent += 1;
-    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
-    g.wln("%v0 = load i8, i8* %p");
-    g.wln("%d8 = trunc i32 %delta to i8");
-    g.wln("%v1 = add i8 %v0, %d8");
-    g.wln("store i8 %v1, i8* %p");
-    g.wln("ret void");
+    g.line("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.line("%v0 = load i8, i8* %p");
+    g.line("%d8 = trunc i32 %delta to i8");
+    g.line("%v1 = add i8 %v0, %d8");
+    g.line("store i8 %v1, i8* %p");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Output
-    g.wln("define internal void @bf_output(%State* nocapture nonnull %S) nounwind {");
+    g.line("define internal void @bf_output(%State* nocapture nonnull %S) nounwind {");
     g.indent += 1;
-    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
-    g.wln("%v = load i8, i8* %p");
-    g.wln("%w = zext i8 %v to i32");
-    g.wln("call i32 @putchar(i32 %w)");
-    g.wln("ret void");
+    g.line("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.line("%v = load i8, i8* %p");
+    g.line("%w = zext i8 %v to i32");
+    g.line("call i32 @putchar(i32 %w)");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Input
-    g.wln("define internal void @bf_input(%State* nocapture nonnull %S) nounwind {");
+    g.line("define internal void @bf_input(%State* nocapture nonnull %S) nounwind {");
     g.indent += 1;
-    g.wln("%c = call i32 @getchar()");
-    g.wln("%eof = icmp slt i32 %c, 0");
-    g.wln("%cz = select i1 %eof, i32 0, i32 %c");
-    g.wln("%b = trunc i32 %cz to i8");
-    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
-    g.wln("store i8 %b, i8* %p");
-    g.wln("ret void");
+    g.line("%c = call i32 @getchar()");
+    g.line("%eof = icmp slt i32 %c, 0");
+    g.line("%cz = select i1 %eof, i32 0, i32 %c");
+    g.line("%b = trunc i32 %cz to i8");
+    g.line("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.line("store i8 %b, i8* %p");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Wait (0.1s * ticks)
-    g.wln("define internal void @bf_wait(i32 %ticks) nounwind {");
+    g.line("define internal void @bf_wait(i32 %ticks) nounwind {");
     g.indent += 1;
-    g.wln("%u = mul i32 %ticks, 100000");
-    g.wln("call i32 @usleep(i32 %u)");
-    g.wln("ret void");
+    g.line("%u = mul i32 %ticks, 100000");
+    g.line("call i32 @usleep(i32 %u)");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Acquire lock (then push)
-    g.wln("define internal void @bf_lock_acquire(%State* nocapture nonnull %S) nounwind {");
+    g.line("define internal void @bf_lock_acquire(%State* nocapture nonnull %S) nounwind {");
     g.indent += 1;
-    g.wln("%fld_ptr2 = getelementptr %State,%State* %S, i32 0, i32 1");
-    g.wln("%idx = load i64, i64* %fld_ptr2");
-    g.wln("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
-    g.wln("call i32 @pthread_mutex_lock(i8* %slot)");
-    g.wln("call void @push_lock(%State* %S, i64 %idx)");
-    g.wln("ret void");
+    g.line("%fld_ptr2 = getelementptr %State,%State* %S, i32 0, i32 1");
+    g.line("%idx = load i64, i64* %fld_ptr2");
+    g.line("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
+    g.line("call i32 @pthread_mutex_lock(i8* %slot)");
+    g.line("call void @push_lock(%State* %S, i64 %idx)");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 
     // Release lock (pop then unlock)
-    g.wln("define internal void @bf_lock_release(%State* nocapture nonnull %S) nounwind {");
+    g.line("define internal void @bf_lock_release(%State* nocapture nonnull %S) nounwind {");
     g.indent += 1;
-    g.wln("%idx = call i64 @pop_lock(%State* %S)");
-    g.wln("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
-    g.wln("call i32 @pthread_mutex_unlock(i8* %slot)");
-    g.wln("ret void");
+    g.line("%idx = call i64 @pop_lock(%State* %S)");
+    g.line("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
+    g.line("call i32 @pthread_mutex_unlock(i8* %slot)");
+    g.line("ret void");
     g.indent -= 1;
-    g.wln("}");
+    g.line("}");
 }

--- a/src/codegen/decl.rs
+++ b/src/codegen/decl.rs
@@ -1,0 +1,171 @@
+use super::{Codegen, LOCK_STACK_INIT, MUTEX_STRIDE, TAPE_LEN};
+
+pub fn decl_externals(g: &mut Codegen) {
+    g.wln("declare i32 @putchar(i32)");
+    g.wln("declare i32 @getchar()");
+    g.wln("declare i32 @usleep(i32)");
+    g.wln("declare i8* @malloc(i64)");
+    g.wln("declare void @free(i8*)");
+    g.wln("declare i32 @pthread_create(i64*, i8*, i8* (i8*)*, i8*)");
+    g.wln("declare i32 @pthread_join(i64, i8**)");
+    g.wln("declare i32 @pthread_mutex_init(i8*, i8*)");
+    g.wln("declare i32 @pthread_mutex_lock(i8*)");
+    g.wln("declare i32 @pthread_mutex_unlock(i8*)");
+    // memcpy intrinsic（stack の拡張に使用）
+    g.wln("declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1 immarg)");
+}
+
+pub fn define_runtime_helpers(g: &mut Codegen) {
+    // --- GEP: 現在セルのポインタ ---
+    g.wln("define internal i8* @bf_gep_cell_ptr(%State* nocapture nonnull %S) alwaysinline nounwind {");
+    g.indent += 1;
+    g.wln("%fld_base = getelementptr %State, %State* %S, i32 0, i32 0");
+    g.wln("%base = load i8*, i8** %fld_base");
+    g.wln("%fld_idx = getelementptr %State, %State* %S, i32 0, i32 1");
+    g.wln("%idx  = load i64,  i64*  %fld_idx");
+    g.wln("%p    = getelementptr i8, i8* %base, i64 %idx");
+    g.wln("ret i8* %p");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- ロックスロットのアドレス（mutex_slab + idx*stride） ---
+    g.wln("define internal i8* @bf_lock_slot_addr(%State* nocapture nonnull %S, i64 %idx) alwaysinline nounwind {");
+    g.indent += 1;
+    g.wln("%fld_slab = getelementptr %State, %State* %S, i32 0, i32 2");
+    g.wln("%slab = load i8*, i8** %fld_slab");
+    g.wln(&format!("%off  = mul i64 %idx, {MUTEX_STRIDE}"));
+    g.wln("%slot = getelementptr i8, i8* %slab, i64 %off");
+    g.wln("ret i8* %slot");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- push_lock(%S, idx) : 動的拡張あり ---
+    g.wln("define internal void @push_lock(%State* nocapture nonnull %S, i64 %idx) nounwind {");
+    g.indent += 1;
+    g.wln("%fld_sp = getelementptr %State, %State* %S, i32 0, i32 4");
+    g.wln("%sp  = load i64,  i64*  %fld_sp");
+    g.wln("%fld_cap = getelementptr %State, %State* %S, i32 0, i32 5");
+    g.wln("%cap = load i64,  i64*  %fld_cap");
+    g.wln("%need_grow = icmp eq i64 %sp, %cap");
+    g.wln("br i1 %need_grow, label %grow, label %push");
+
+    g.wln("grow:");
+    g.wln("%fld_buf = getelementptr %State, %State* %S, i32 0, i32 3");
+    g.wln("%oldbuf = load i64*, i64** %fld_buf");
+    g.wln("%oldcap = load i64, i64* %fld_cap");
+    g.wln("%newcap = shl i64 %oldcap, 1");
+    g.wln("%oldbytes = mul i64 %oldcap, 8");
+    g.wln("%newbytes = mul i64 %newcap, 8");
+    g.wln("%newraw = call i8* @malloc(i64 %newbytes)");
+    g.wln("%newbuf = bitcast i8* %newraw to i64*");
+    g.wln("%dst = bitcast i64* %newbuf to i8*");
+    g.wln("%src = bitcast i64* %oldbuf to i8*");
+    g.wln("call void @llvm.memcpy.p0i8.p0i8.i64(i8* %dst, i8* %src, i64 %oldbytes, i1 false)");
+    g.wln("call void @free(i8* %src)");
+    g.wln("store i64* %newbuf, i64** %fld_buf");
+    g.wln("store i64  %newcap, i64*  %fld_cap");
+    g.wln("br label %push");
+
+    g.wln("push:");
+    g.wln("%buf = load i64*, i64** %fld_buf");
+    g.wln("%slotp = getelementptr i64, i64* %buf, i64 %sp");
+    g.wln("store i64 %idx, i64* %slotp");
+    g.wln("%sp1 = add i64 %sp, 1");
+    g.wln("store i64 %sp1, i64* %fld_sp");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- pop_lock(%S) -> i64（空は未定義：パーサ側で検査前提） ---
+    g.wln("define internal i64 @pop_lock(%State* nocapture nonnull %S) nounwind {");
+    g.indent += 1;
+    g.wln("%fld_sp2 = getelementptr %State, %State* %S, i32 0, i32 4");
+    g.wln("%sp  = load i64, i64* %fld_sp2");
+    g.wln("%sp1 = add i64 %sp, -1");
+    g.wln("store i64 %sp1, i64* %fld_sp2");
+    g.wln("%fld_buf2 = getelementptr %State, %State* %S, i32 0, i32 3");
+    g.wln("%buf = load i64*, i64** %fld_buf2");
+    g.wln("%slotp = getelementptr i64, i64* %buf, i64 %sp1");
+    g.wln("%idx = load i64, i64* %slotp");
+    g.wln("ret i64 %idx");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- 基本命令: ポインタ移動 ---
+    g.wln("define internal void @bf_inc_ptr(%State* nocapture nonnull %S, i64 %delta) alwaysinline nounwind {");
+    g.indent += 1;
+    g.wln("%fld_ptr = getelementptr %State,%State* %S, i32 0, i32 1");
+    g.wln("%v = load i64, i64* %fld_ptr");
+    g.wln("%u = add i64 %v, %delta");
+    g.wln("store i64 %u, i64* %fld_ptr");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- 基本命令: セル加算（非 atomic） ---
+    g.wln("define internal void @bf_add_cell(%State* nocapture nonnull %S, i32 %delta) alwaysinline nounwind {");
+    g.indent += 1;
+    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.wln("%v0 = load i8, i8* %p");
+    g.wln("%d8 = trunc i32 %delta to i8");
+    g.wln("%v1 = add i8 %v0, %d8");
+    g.wln("store i8 %v1, i8* %p");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- 出力 ---
+    g.wln("define internal void @bf_output(%State* nocapture nonnull %S) nounwind {");
+    g.indent += 1;
+    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.wln("%v = load i8, i8* %p");
+    g.wln("%w = zext i8 %v to i32");
+    g.wln("call i32 @putchar(i32 %w)");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- 入力 ---
+    g.wln("define internal void @bf_input(%State* nocapture nonnull %S) nounwind {");
+    g.indent += 1;
+    g.wln("%c = call i32 @getchar()");
+    g.wln("%eof = icmp slt i32 %c, 0");
+    g.wln("%cz = select i1 %eof, i32 0, i32 %c");
+    g.wln("%b = trunc i32 %cz to i8");
+    g.wln("%p = call i8* @bf_gep_cell_ptr(%State* %S)");
+    g.wln("store i8 %b, i8* %p");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- 待機（0.1s * ticks）---
+    g.wln("define internal void @bf_wait(i32 %ticks) nounwind {");
+    g.indent += 1;
+    g.wln("%u = mul i32 %ticks, 100000");
+    g.wln("call i32 @usleep(i32 %u)");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- ロック取得（成功後に push） ---
+    g.wln("define internal void @bf_lock_acquire(%State* nocapture nonnull %S) nounwind {");
+    g.indent += 1;
+    g.wln("%fld_ptr2 = getelementptr %State,%State* %S, i32 0, i32 1");
+    g.wln("%idx = load i64, i64* %fld_ptr2");
+    g.wln("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
+    g.wln("call i32 @pthread_mutex_lock(i8* %slot)");
+    g.wln("call void @push_lock(%State* %S, i64 %idx)");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+
+    // --- ロック解放（pop した idx に対して unlock） ---
+    g.wln("define internal void @bf_lock_release(%State* nocapture nonnull %S) nounwind {");
+    g.indent += 1;
+    g.wln("%idx = call i64 @pop_lock(%State* %S)");
+    g.wln("%slot = call i8* @bf_lock_slot_addr(%State* %S, i64 %idx)");
+    g.wln("call i32 @pthread_mutex_unlock(i8* %slot)");
+    g.wln("ret void");
+    g.indent -= 1;
+    g.wln("}");
+}

--- a/src/codegen/decl.rs
+++ b/src/codegen/decl.rs
@@ -46,11 +46,12 @@ pub fn define_runtime_helpers(g: &mut Codegen) {
     g.wln("%sp  = load i64,  i64*  %fld_sp");
     g.wln("%fld_cap = getelementptr %State, %State* %S, i32 0, i32 5");
     g.wln("%cap = load i64,  i64*  %fld_cap");
+    // fld_buf を分岐前に計算して優位性を確保
+    g.wln("%fld_buf = getelementptr %State, %State* %S, i32 0, i32 3");
     g.wln("%need_grow = icmp eq i64 %sp, %cap");
     g.wln("br i1 %need_grow, label %grow, label %push");
 
     g.wln("grow:");
-    g.wln("%fld_buf = getelementptr %State, %State* %S, i32 0, i32 3");
     g.wln("%oldbuf = load i64*, i64** %fld_buf");
     g.wln("%oldcap = load i64, i64* %fld_cap");
     g.wln("%newcap = shl i64 %oldcap, 1");

--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -9,15 +9,15 @@ pub fn emit_nodes(g: &mut Codegen, s: &str, nodes: &[Node]) {
 
 fn emit_node(g: &mut Codegen, s: &str, n: &Node) {
     match n {
-        Node::IncPtr => g.wln(&format!("call void @bf_inc_ptr(%State* {s}, i64 1)")),
-        Node::DecPtr => g.wln(&format!("call void @bf_inc_ptr(%State* {s}, i64 -1)")),
-        Node::IncCell => g.wln(&format!("call void @bf_add_cell(%State* {s}, i32 1)")),
-        Node::DecCell => g.wln(&format!("call void @bf_add_cell(%State* {s}, i32 -1)")),
-        Node::Output => g.wln(&format!("call void @bf_output(%State* {s})")),
-        Node::Input => g.wln(&format!("call void @bf_input(%State* {s})")),
-        Node::LockAcquire => g.wln(&format!("call void @bf_lock_acquire(%State* {s})")),
-        Node::LockRelease => g.wln(&format!("call void @bf_lock_release(%State* {s})")),
-        Node::Wait(t) => g.wln(&format!("call void @bf_wait(i32 {t})")),
+        Node::IncPtr => g.line(&format!("call void @bf_inc_ptr(%State* {s}, i64 1)")),
+        Node::DecPtr => g.line(&format!("call void @bf_inc_ptr(%State* {s}, i64 -1)")),
+        Node::IncCell => g.line(&format!("call void @bf_add_cell(%State* {s}, i32 1)")),
+        Node::DecCell => g.line(&format!("call void @bf_add_cell(%State* {s}, i32 -1)")),
+        Node::Output => g.line(&format!("call void @bf_output(%State* {s})")),
+        Node::Input => g.line(&format!("call void @bf_input(%State* {s})")),
+        Node::LockAcquire => g.line(&format!("call void @bf_lock_acquire(%State* {s})")),
+        Node::LockRelease => g.line(&format!("call void @bf_lock_release(%State* {s})")),
+        Node::Wait(t) => g.line(&format!("call void @bf_wait(i32 {t})")),
         Node::Loop(body) => emit_loop(g, s, body),
         Node::Parallel(bs) => parallel::emit_parallel(g, s, bs),
     }
@@ -30,16 +30,16 @@ fn emit_loop(g: &mut Codegen, s: &str, body: &[Node]) {
     let l_body = format!("loop.body.{id}");
     let l_end = format!("loop.end.{id}");
 
-    g.wln(&format!("br label %{l_cond}"));
+    g.line(&format!("br label %{l_cond}"));
     g.label(&l_cond);
-    g.wln(&format!("%p{id} = call i8* @bf_gep_cell_ptr(%State* {s})"));
-    g.wln(&format!("%v{id} = load i8, i8* %p{id}"));
-    g.wln(&format!("%nz{id} = icmp ne i8 %v{id}, 0"));
-    g.wln(&format!("br i1 %nz{id}, label %{l_body}, label %{l_end}"));
+    g.line(&format!("%p{id} = call i8* @bf_gep_cell_ptr(%State* {s})"));
+    g.line(&format!("%v{id} = load i8, i8* %p{id}"));
+    g.line(&format!("%nz{id} = icmp ne i8 %v{id}, 0"));
+    g.line(&format!("br i1 %nz{id}, label %{l_body}, label %{l_end}"));
 
     g.label(&l_body);
     emit_nodes(g, s, body);
-    g.wln(&format!("br label %{l_cond}"));
+    g.line(&format!("br label %{l_cond}"));
 
     g.label(&l_end);
 }

--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -1,0 +1,45 @@
+use super::{Codegen, parallel};
+use crate::parser::Node;
+
+pub fn emit_nodes(g: &mut Codegen, s: &str, nodes: &[Node]) {
+    for n in nodes {
+        emit_node(g, s, n);
+    }
+}
+
+fn emit_node(g: &mut Codegen, s: &str, n: &Node) {
+    match n {
+        Node::IncPtr => g.wln(&format!("call void @bf_inc_ptr(%State* {s}, i64 1)")),
+        Node::DecPtr => g.wln(&format!("call void @bf_inc_ptr(%State* {s}, i64 -1)")),
+        Node::IncCell => g.wln(&format!("call void @bf_add_cell(%State* {s}, i32 1)")),
+        Node::DecCell => g.wln(&format!("call void @bf_add_cell(%State* {s}, i32 -1)")),
+        Node::Output => g.wln(&format!("call void @bf_output(%State* {s})")),
+        Node::Input => g.wln(&format!("call void @bf_input(%State* {s})")),
+        Node::LockAcquire => g.wln(&format!("call void @bf_lock_acquire(%State* {s})")),
+        Node::LockRelease => g.wln(&format!("call void @bf_lock_release(%State* {s})")),
+        Node::Wait(t) => g.wln(&format!("call void @bf_wait(i32 {t})")),
+        Node::Loop(body) => emit_loop(g, s, body),
+        Node::Parallel(bs) => parallel::emit_parallel(g, s, bs),
+    }
+}
+
+fn emit_loop(g: &mut Codegen, s: &str, body: &[Node]) {
+    let id = g.uniq;
+    g.uniq += 1;
+    let l_cond = format!("loop.cond.{id}");
+    let l_body = format!("loop.body.{id}");
+    let l_end = format!("loop.end.{id}");
+
+    g.wln(&format!("br label %{l_cond}"));
+    g.label(&l_cond);
+    g.wln(&format!("%p{id} = call i8* @bf_gep_cell_ptr(%State* {s})"));
+    g.wln(&format!("%v{id} = load i8, i8* %p{id}"));
+    g.wln(&format!("%nz{id} = icmp ne i8 %v{id}, 0"));
+    g.wln(&format!("br i1 %nz{id}, label %{l_body}, label %{l_end}"));
+
+    g.label(&l_body);
+    emit_nodes(g, s, body);
+    g.wln(&format!("br label %{l_cond}"));
+
+    g.label(&l_end);
+}

--- a/src/codegen/parallel.rs
+++ b/src/codegen/parallel.rs
@@ -1,0 +1,94 @@
+use super::{Codegen, LOCK_STACK_INIT, emit};
+
+use crate::parser::Node;
+
+/// 並列ブロック `{ A | B | ... }`
+/// 親 %S を参照しつつ、各枝に独立 State を用意して起動・join。
+pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
+    let pid = g.uniq;
+    g.uniq += 1;
+    let k = branches.len();
+
+    // 1) 各枝の thunk / thread_start を前方定義
+    for (i, b) in branches.iter().enumerate() {
+        let tname = format!("p{pid}_{i}");
+        g.define_thunk(&tname, b);
+        g.wln(&format!(
+            "define internal i8* @thread_start_{tname}(i8* %arg) nounwind {{"
+        ));
+        g.indent += 1;
+        g.wln("%S = bitcast i8* %arg to %State*");
+        g.wln(&format!("call void @thunk_{tname}(%State* %S)"));
+        g.wln("ret i8* null");
+        g.indent -= 1;
+        g.wln("}");
+        g.wln("");
+    }
+
+    // 2) 親関数本体で threads 配列を確保して起動
+    g.wln(&format!("%threads{pid} = alloca [{} x i64]", k));
+    for i in 0..k {
+        let child = fresh(g, "Schild");
+        // sizeof(%State)
+        g.wln(&format!("%st_bytes{pid}_{i} = ptrtoint (%State* getelementptr(%State, %State* null, i32 1) to i64)"));
+        g.wln(&format!(
+            "%st{pid}_{i} = call i8* @malloc(i64 %st_bytes{pid}_{i})"
+        ));
+        g.wln(&format!("{child} = bitcast i8* %st{pid}_{i} to %State*"));
+
+        // tape_base / ptr_index / mutex_slab の継承
+        // base
+        g.wln(&format!("%fld_parent_base{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 0"));
+        g.wln(&format!("%base{pid}_{i} = load i8*, i8** %fld_parent_base{pid}_{i}"));
+        g.wln(&format!("%fld_child_base{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 0"));
+        g.wln(&format!("store i8* %base{pid}_{i}, i8** %fld_child_base{pid}_{i}"));
+        // idx
+        g.wln(&format!("%fld_parent_idx{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 1"));
+        g.wln(&format!("%idx{pid}_{i}  = load i64,  i64*  %fld_parent_idx{pid}_{i}"));
+        g.wln(&format!("%fld_child_idx{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 1"));
+        g.wln(&format!("store i64 %idx{pid}_{i},  i64*  %fld_child_idx{pid}_{i}"));
+        // slab
+        g.wln(&format!("%fld_parent_sl{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 2"));
+        g.wln(&format!("%sl{pid}_{i}   = load i8*, i8** %fld_parent_sl{pid}_{i}"));
+        g.wln(&format!("%fld_child_sl{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 2"));
+        g.wln(&format!("store i8* %sl{pid}_{i},   i8** %fld_child_sl{pid}_{i}"));
+
+        // lock stack 新規
+        g.wln(&format!("%lsz{pid}_{i} = mul i64 {LOCK_STACK_INIT}, 8"));
+        g.wln(&format!(
+            "%stk{pid}_{i} = call i8* @malloc(i64 %lsz{pid}_{i})"
+        ));
+        g.wln(&format!(
+            "%stk64{pid}_{i} = bitcast i8* %stk{pid}_{i} to i64*"
+        ));
+        g.wln(&format!("%fld_child_stk{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 3"));
+        g.wln(&format!("store i64* %stk64{pid}_{i}, i64** %fld_child_stk{pid}_{i}"));
+        g.wln(&format!("%fld_child_sp{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 4"));
+        g.wln(&format!("store i64 0, i64* %fld_child_sp{pid}_{i}"));
+        g.wln(&format!("%fld_child_cap{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 5"));
+        g.wln(&format!("store i64 {LOCK_STACK_INIT}, i64* %fld_child_cap{pid}_{i}"));
+
+        // pthread_create
+        g.wln(&format!(
+            "%tptr{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"
+        ));
+        g.wln(&format!("%arg{pid}_{i} = bitcast %State* {child} to i8*"));
+        g.wln(&format!(
+            "call i32 @pthread_create(i64* %tptr{pid}_{i}, i8* null, i8* (i8*)* @thread_start_p{pid}_{i}, i8* %arg{pid}_{i})"
+        ));
+    }
+
+    // 3) join
+    for i in 0..k {
+        g.wln(&format!("%tval{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"));
+        g.wln(&format!("%tload{pid}_{i} = load i64, i64* %tval{pid}_{i}"));
+        g.wln(&format!(
+            "call i32 @pthread_join(i64 %tload{pid}_{i}, i8** null)"
+        ));
+        // （必要なら %Schild の解放、stack の解放を追記できる）
+    }
+}
+
+fn fresh(g: &mut Codegen, p: &str) -> String {
+    g.fresh(p)
+}

--- a/src/codegen/parallel.rs
+++ b/src/codegen/parallel.rs
@@ -9,51 +9,62 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
     g.uniq += 1;
     let k = branches.len();
 
-    // 1) 各枝の thunk / thread_start を前方定義
+    // 1) 各枝の thunk / thread_start を遅延定義バッファへ
     for (i, b) in branches.iter().enumerate() {
         let tname = format!("p{pid}_{i}");
-        g.define_thunk(&tname, b);
-        g.wln(&format!(
-            "define internal i8* @thread_start_{tname}(i8* %arg) nounwind {{"
-        ));
-        g.indent += 1;
-        g.wln("%S = bitcast i8* %arg to %State*");
-        g.wln(&format!("call void @thunk_{tname}(%State* %S)"));
-        g.wln("ret i8* null");
-        g.indent -= 1;
-        g.wln("}");
-        g.wln("");
+        g.defer_thunk(&tname, b);
+        g.defer_thread_start(&tname);
     }
 
     // 2) 親関数本体で threads 配列を確保して起動
     g.wln(&format!("%threads{pid} = alloca [{} x i64]", k));
     for i in 0..k {
         let child = fresh(g, "Schild");
-        // sizeof(%State)
         g.wln(&format!("%st_bytes{pid}_{i} = ptrtoint (%State* getelementptr(%State, %State* null, i32 1) to i64)"));
         g.wln(&format!(
             "%st{pid}_{i} = call i8* @malloc(i64 %st_bytes{pid}_{i})"
         ));
         g.wln(&format!("{child} = bitcast i8* %st{pid}_{i} to %State*"));
-
-        // tape_base / ptr_index / mutex_slab の継承
         // base
-        g.wln(&format!("%fld_parent_base{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 0"));
-        g.wln(&format!("%base{pid}_{i} = load i8*, i8** %fld_parent_base{pid}_{i}"));
-        g.wln(&format!("%fld_child_base{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 0"));
-        g.wln(&format!("store i8* %base{pid}_{i}, i8** %fld_child_base{pid}_{i}"));
+        g.wln(&format!(
+            "%fld_parent_base{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 0"
+        ));
+        g.wln(&format!(
+            "%base{pid}_{i} = load i8*, i8** %fld_parent_base{pid}_{i}"
+        ));
+        g.wln(&format!(
+            "%fld_child_base{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 0"
+        ));
+        g.wln(&format!(
+            "store i8* %base{pid}_{i}, i8** %fld_child_base{pid}_{i}"
+        ));
         // idx
-        g.wln(&format!("%fld_parent_idx{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 1"));
-        g.wln(&format!("%idx{pid}_{i}  = load i64,  i64*  %fld_parent_idx{pid}_{i}"));
-        g.wln(&format!("%fld_child_idx{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 1"));
-        g.wln(&format!("store i64 %idx{pid}_{i},  i64*  %fld_child_idx{pid}_{i}"));
+        g.wln(&format!(
+            "%fld_parent_idx{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 1"
+        ));
+        g.wln(&format!(
+            "%idx{pid}_{i}  = load i64,  i64*  %fld_parent_idx{pid}_{i}"
+        ));
+        g.wln(&format!(
+            "%fld_child_idx{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 1"
+        ));
+        g.wln(&format!(
+            "store i64 %idx{pid}_{i},  i64*  %fld_child_idx{pid}_{i}"
+        ));
         // slab
-        g.wln(&format!("%fld_parent_sl{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 2"));
-        g.wln(&format!("%sl{pid}_{i}   = load i8*, i8** %fld_parent_sl{pid}_{i}"));
-        g.wln(&format!("%fld_child_sl{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 2"));
-        g.wln(&format!("store i8* %sl{pid}_{i},   i8** %fld_child_sl{pid}_{i}"));
-
-        // lock stack 新規
+        g.wln(&format!(
+            "%fld_parent_sl{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 2"
+        ));
+        g.wln(&format!(
+            "%sl{pid}_{i}   = load i8*, i8** %fld_parent_sl{pid}_{i}"
+        ));
+        g.wln(&format!(
+            "%fld_child_sl{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 2"
+        ));
+        g.wln(&format!(
+            "store i8* %sl{pid}_{i},   i8** %fld_child_sl{pid}_{i}"
+        ));
+        // lock stack
         g.wln(&format!("%lsz{pid}_{i} = mul i64 {LOCK_STACK_INIT}, 8"));
         g.wln(&format!(
             "%stk{pid}_{i} = call i8* @malloc(i64 %lsz{pid}_{i})"
@@ -61,31 +72,39 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
         g.wln(&format!(
             "%stk64{pid}_{i} = bitcast i8* %stk{pid}_{i} to i64*"
         ));
-        g.wln(&format!("%fld_child_stk{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 3"));
-        g.wln(&format!("store i64* %stk64{pid}_{i}, i64** %fld_child_stk{pid}_{i}"));
-        g.wln(&format!("%fld_child_sp{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 4"));
+        g.wln(&format!(
+            "%fld_child_stk{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 3"
+        ));
+        g.wln(&format!(
+            "store i64* %stk64{pid}_{i}, i64** %fld_child_stk{pid}_{i}"
+        ));
+        g.wln(&format!(
+            "%fld_child_sp{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 4"
+        ));
         g.wln(&format!("store i64 0, i64* %fld_child_sp{pid}_{i}"));
-        g.wln(&format!("%fld_child_cap{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 5"));
-        g.wln(&format!("store i64 {LOCK_STACK_INIT}, i64* %fld_child_cap{pid}_{i}"));
-
+        g.wln(&format!(
+            "%fld_child_cap{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 5"
+        ));
+        g.wln(&format!(
+            "store i64 {LOCK_STACK_INIT}, i64* %fld_child_cap{pid}_{i}"
+        ));
         // pthread_create
         g.wln(&format!(
             "%tptr{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"
         ));
         g.wln(&format!("%arg{pid}_{i} = bitcast %State* {child} to i8*"));
-        g.wln(&format!(
-            "call i32 @pthread_create(i64* %tptr{pid}_{i}, i8* null, i8* (i8*)* @thread_start_p{pid}_{i}, i8* %arg{pid}_{i})"
-        ));
+        g.wln(&format!("call i32 @pthread_create(i64* %tptr{pid}_{i}, i8* null, i8* (i8*)* @thread_start_p{pid}_{i}, i8* %arg{pid}_{i})"));
     }
 
     // 3) join
     for i in 0..k {
-        g.wln(&format!("%tval{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"));
+        g.wln(&format!(
+            "%tval{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"
+        ));
         g.wln(&format!("%tload{pid}_{i} = load i64, i64* %tval{pid}_{i}"));
         g.wln(&format!(
             "call i32 @pthread_join(i64 %tload{pid}_{i}, i8** null)"
         ));
-        // （必要なら %Schild の解放、stack の解放を追記できる）
     }
 }
 

--- a/src/codegen/parallel.rs
+++ b/src/codegen/parallel.rs
@@ -16,98 +16,98 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
     }
 
     // In parent function: allocate threads array and launch
-    g.wln(&format!("%threads{pid} = alloca [{k} x i64]"));
+    g.line(&format!("%threads{pid} = alloca [{k} x i64]"));
     for i in 0..k {
         let child = fresh(g, "Schild");
         // Separate GEP for struct size calculation
-        g.wln(&format!(
+        g.line(&format!(
             "%st_end{pid}_{i} = getelementptr %State, %State* null, i32 1"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%st_bytes{pid}_{i} = ptrtoint %State* %st_end{pid}_{i} to i64"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%st{pid}_{i} = call i8* @malloc(i64 %st_bytes{pid}_{i})"
         ));
-        g.wln(&format!("{child} = bitcast i8* %st{pid}_{i} to %State*"));
+        g.line(&format!("{child} = bitcast i8* %st{pid}_{i} to %State*"));
         // base
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_parent_base{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 0"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%base{pid}_{i} = load i8*, i8** %fld_parent_base{pid}_{i}"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_child_base{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 0"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "store i8* %base{pid}_{i}, i8** %fld_child_base{pid}_{i}"
         ));
         // idx
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_parent_idx{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 1"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%idx{pid}_{i}  = load i64,  i64*  %fld_parent_idx{pid}_{i}"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_child_idx{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 1"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "store i64 %idx{pid}_{i},  i64*  %fld_child_idx{pid}_{i}"
         ));
         // slab
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_parent_sl{pid}_{i} = getelementptr %State,%State* {parent_s}, i32 0, i32 2"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%sl{pid}_{i}   = load i8*, i8** %fld_parent_sl{pid}_{i}"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_child_sl{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 2"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "store i8* %sl{pid}_{i},   i8** %fld_child_sl{pid}_{i}"
         ));
         // lock stack
-        g.wln(&format!("%lsz{pid}_{i} = mul i64 {LOCK_STACK_INIT}, 8"));
-        g.wln(&format!(
+        g.line(&format!("%lsz{pid}_{i} = mul i64 {LOCK_STACK_INIT}, 8"));
+        g.line(&format!(
             "%stk{pid}_{i} = call i8* @malloc(i64 %lsz{pid}_{i})"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%stk64{pid}_{i} = bitcast i8* %stk{pid}_{i} to i64*"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_child_stk{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 3"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "store i64* %stk64{pid}_{i}, i64** %fld_child_stk{pid}_{i}"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "%fld_child_sp{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 4"
         ));
-        g.wln(&format!("store i64 0, i64* %fld_child_sp{pid}_{i}"));
-        g.wln(&format!(
+        g.line(&format!("store i64 0, i64* %fld_child_sp{pid}_{i}"));
+        g.line(&format!(
             "%fld_child_cap{pid}_{i} = getelementptr %State,%State* {child}, i32 0, i32 5"
         ));
-        g.wln(&format!(
+        g.line(&format!(
             "store i64 {LOCK_STACK_INIT}, i64* %fld_child_cap{pid}_{i}"
         ));
         // pthread_create
-        g.wln(&format!(
+        g.line(&format!(
             "%tptr{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"
         ));
-        g.wln(&format!("%arg{pid}_{i} = bitcast %State* {child} to i8*"));
-        g.wln(&format!("call i32 @pthread_create(i64* %tptr{pid}_{i}, i8* null, i8* (i8*)* @thread_start_p{pid}_{i}, i8* %arg{pid}_{i})"));
+        g.line(&format!("%arg{pid}_{i} = bitcast %State* {child} to i8*"));
+        g.line(&format!("call i32 @pthread_create(i64* %tptr{pid}_{i}, i8* null, i8* (i8*)* @thread_start_p{pid}_{i}, i8* %arg{pid}_{i})"));
     }
 
     // Join all threads
     for i in 0..k {
-        g.wln(&format!(
+        g.line(&format!(
             "%tval{pid}_{i} = getelementptr [{k} x i64], [{k} x i64]* %threads{pid}, i64 0, i64 {i}"
         ));
-        g.wln(&format!("%tload{pid}_{i} = load i64, i64* %tval{pid}_{i}"));
-        g.wln(&format!(
+        g.line(&format!("%tload{pid}_{i} = load i64, i64* %tval{pid}_{i}"));
+        g.line(&format!(
             "call i32 @pthread_join(i64 %tload{pid}_{i}, i8** null)"
         ));
     }

--- a/src/codegen/parallel.rs
+++ b/src/codegen/parallel.rs
@@ -20,7 +20,13 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
     g.wln(&format!("%threads{pid} = alloca [{} x i64]", k));
     for i in 0..k {
         let child = fresh(g, "Schild");
-        g.wln(&format!("%st_bytes{pid}_{i} = ptrtoint (%State* getelementptr(%State, %State* null, i32 1) to i64)"));
+        // サイズ計算: GEP を分離
+        g.wln(&format!(
+            "%st_end{pid}_{i} = getelementptr %State, %State* null, i32 1"
+        ));
+        g.wln(&format!(
+            "%st_bytes{pid}_{i} = ptrtoint %State* %st_end{pid}_{i} to i64"
+        ));
         g.wln(&format!(
             "%st{pid}_{i} = call i8* @malloc(i64 %st_bytes{pid}_{i})"
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,31 +2,40 @@
 
 use std::{env, fs, io, process};
 
-use crate::interpreter::Interpreter;
-
+mod codegen;
 mod interpreter;
 mod lexer;
 mod parser;
 
+fn usage(prog: &str) -> ! {
+    eprintln!("Usage: {prog} (compile|c|interpret|i) <source.bf>");
+    process::exit(1);
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: {} <path>", args[0]);
-        process::exit(1);
-    }
 
-    let file_path = &args[1];
-    let contents = fs::read_to_string(file_path).unwrap_or_else(|err| {
-        eprintln!("Failed to read file: {file_path}: {err}");
+    let prog = args.first().unwrap();
+    let cmd = args.get(1).unwrap_or_else(|| usage(prog));
+    let path = args.get(2).unwrap_or_else(|| usage(prog));
+
+    let contents = fs::read_to_string(path).unwrap_or_else(|err| {
+        eprintln!("Failed to read file: {path}: {err}");
         process::exit(1);
     });
 
     let tokens = lexer::lex(&contents);
     let nodes = parser::parse(&tokens);
 
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    let interpreter = Interpreter::new(stdin, stdout);
-
-    interpreter.run(&nodes).unwrap();
+    match cmd.as_str() {
+        "compile" | "c" => {
+            let ir = codegen::generate_ir(&nodes);
+            println!("{ir}");
+        }
+        "interpret" | "i" => {
+            let interpreter = interpreter::Interpreter::new(io::stdin(), io::stdout());
+            interpreter.run(&nodes).unwrap();
+        }
+        _ => usage(prog),
+    }
 }


### PR DESCRIPTION
## Summary

GPT-5 と GPT-5 Thinking を使用し、コンパイラを実装した。

## Description

コンパイラは LLVM-IR を出力する。

**出力する LLVM-IR の設計**

- 各 Brainfork 命令を関数ごとに切り出して実行
- スレッドの実装には `pthread`, `pthread_mutex_*` を使用 (libc 依存)
  - 各スレッドは `%State*` を引数とする `@thunk_pX_Y` 関数として生成され、独立した `%State` インスタンスを持つ
- 各セルに専用の `pthread_mutex_t` を用意し、Tape と Mutex 群を各スレッド間で共有する
- ロック順を保存するために各スレッドでロックしたセルを記録するスタックを持つ

参考: スレッドごとの `%State` 構造体

```llvm
%State = type { 
    i8*,     ; tape_base
    i64,     ; ptr_index
    i8*,     ; mutex_slab
    i64*,    ; lock_stack
    i64,     ; lock_sp
    i64      ; lock_cap
}
```