### PR TITLE
wait/notify を可能とする新文法を追加

### DIFF
--- a/crates/engine/src/codegen/decl.rs
+++ b/crates/engine/src/codegen/decl.rs
@@ -161,8 +161,8 @@ pub fn define_runtime_helpers(g: &mut Codegen) {
     g.indent -= 1;
     g.line("}");
 
-    // Wait (0.1s * ticks)
-    g.line("define internal void @bf_wait(i32 %ticks) nounwind {");
+    // Sleep (0.1s * ticks)
+    g.line("define internal void @bf_sleep(i32 %ticks) nounwind {");
     g.indent += 1;
     g.line("%u = mul i32 %ticks, 100000");
     g.line("call i32 @usleep(i32 %u)");

--- a/crates/engine/src/codegen/decl.rs
+++ b/crates/engine/src/codegen/decl.rs
@@ -3,6 +3,7 @@ use super::{Codegen, MUTEX_STRIDE};
 pub fn decl_externals(g: &mut Codegen) {
     g.line("declare i32 @putchar(i32)");
     g.line("declare i32 @getchar()");
+    g.line("declare i32 @fflush(i8*)");
     g.line("declare i32 @nanosleep(%timespec*, %timespec*)");
     g.line("declare i8* @malloc(i64)");
     g.line("declare void @free(i8*)");
@@ -144,6 +145,7 @@ pub fn define_runtime_helpers(g: &mut Codegen) {
     g.line("%v = load i8, i8* %p");
     g.line("%w = zext i8 %v to i32");
     g.line("call i32 @putchar(i32 %w)");
+    g.line("call i32 @fflush(i8* null)");
     g.line("ret void");
     g.indent -= 1;
     g.line("}");

--- a/crates/engine/src/codegen/decl.rs
+++ b/crates/engine/src/codegen/decl.rs
@@ -23,6 +23,7 @@ pub fn decl_externals(g: &mut Codegen) {
         g.line("declare void @tsan_read(%State*)");
         g.line("declare void @tsan_write(%State*)");
         g.line("declare void @tsan_fork(i64)");
+        g.line("declare void @tsan_join(i64)");
     }
 
     // memcpy intrinsic (used for expanding the lock stack)

--- a/crates/engine/src/codegen/decl.rs
+++ b/crates/engine/src/codegen/decl.rs
@@ -20,9 +20,9 @@ pub fn decl_externals(g: &mut Codegen) {
         g.line("declare i64 @pthread_self()");
 
         // Thread sanitizer functions
-        g.line("declare void @tsan_post_parent_tid(i64)");
         g.line("declare void @tsan_read(%State*)");
         g.line("declare void @tsan_write(%State*)");
+        g.line("declare void @tsan_fork(i64)");
     }
 
     // memcpy intrinsic (used for expanding the lock stack)

--- a/crates/engine/src/codegen/emit.rs
+++ b/crates/engine/src/codegen/emit.rs
@@ -18,9 +18,10 @@ fn emit_node(g: &mut Codegen, s: &str, n: &Node) {
         Node::LockAcquire => g.line(&format!("call void @bf_lock_acquire(%State* {s})")),
         Node::LockRelease => g.line(&format!("call void @bf_lock_release(%State* {s})")),
         Node::Sleep(t) => g.line(&format!("call void @bf_sleep(i32 {t})")),
+        Node::Wait => g.line(&format!("call void @bf_wait(%State* {s})")),
+        Node::Notify => g.line(&format!("call void @bf_notify(%State* {s})")),
         Node::Loop(body) => emit_loop(g, s, body),
         Node::Parallel(bs) => parallel::emit_parallel(g, s, bs),
-        _ => {} // TODO: Handle Node::Wait and Node::Notify
     }
 }
 

--- a/crates/engine/src/codegen/emit.rs
+++ b/crates/engine/src/codegen/emit.rs
@@ -17,7 +17,7 @@ fn emit_node(g: &mut Codegen, s: &str, n: &Node) {
         Node::Input => g.line(&format!("call void @bf_input(%State* {s})")),
         Node::LockAcquire => g.line(&format!("call void @bf_lock_acquire(%State* {s})")),
         Node::LockRelease => g.line(&format!("call void @bf_lock_release(%State* {s})")),
-        Node::Wait(t) => g.line(&format!("call void @bf_wait(i32 {t})")),
+        Node::Sleep(t) => g.line(&format!("call void @bf_sleep(i32 {t})")),
         Node::Loop(body) => emit_loop(g, s, body),
         Node::Parallel(bs) => parallel::emit_parallel(g, s, bs),
     }

--- a/crates/engine/src/codegen/emit.rs
+++ b/crates/engine/src/codegen/emit.rs
@@ -20,6 +20,7 @@ fn emit_node(g: &mut Codegen, s: &str, n: &Node) {
         Node::Sleep(t) => g.line(&format!("call void @bf_sleep(i32 {t})")),
         Node::Loop(body) => emit_loop(g, s, body),
         Node::Parallel(bs) => parallel::emit_parallel(g, s, bs),
+        _ => {} // TODO: Handle Node::Wait and Node::Notify
     }
 }
 

--- a/crates/engine/src/codegen/mod.rs
+++ b/crates/engine/src/codegen/mod.rs
@@ -109,7 +109,7 @@ impl Codegen {
                 // Post parent thread ID to TSAN
                 this.line("%fld_tid = getelementptr %State, %State* %S, i32 0, i32 6");
                 this.line("%tid_parent = load i64, i64* %fld_tid");
-                this.line("call void @tsan_post_parent_tid(i64 %tid_parent)");
+                this.line("call void @tsan_fork(i64 %tid_parent)");
 
                 // Initialize thread ID if sanitization is enabled
                 this.line("%tid_self = call i64 @pthread_self()");

--- a/crates/engine/src/codegen/mod.rs
+++ b/crates/engine/src/codegen/mod.rs
@@ -141,6 +141,7 @@ impl Codegen {
                 "%State = type { i8*, i64, i8*, i64*, i64, i64 } ; (tape, ptr, slab, stack, sp, cap)",
             );
         }
+        self.line("%timespec = type { i64, i64 } ; (tv_sec, tv_nsec)");
         self.line("");
         decl::decl_externals(self);
         decl::define_runtime_helpers(self);

--- a/crates/engine/src/codegen/mod.rs
+++ b/crates/engine/src/codegen/mod.rs
@@ -130,6 +130,8 @@ impl Codegen {
             "@tape = internal global [{TAPE_LEN} x i8] zeroinitializer"
         ));
         self.line("@mutex_slab = internal global i8* null");
+        self.line("@cond_slab = internal global i8* null");
+        self.line("@cond_mtx_slab = internal global i8* null");
         if self.sanitize {
             self.line(
                 "%State = type { i8*, i64, i8*, i64*, i64, i64, i64 } ; (tape, ptr, slab, stack, sp, cap, tid)",
@@ -153,6 +155,12 @@ impl Codegen {
         self.line(&format!("%slab_bytes = mul i64 {TAPE_LEN}, {MUTEX_STRIDE}"));
         self.line("%slab = call i8* @malloc(i64 %slab_bytes)");
         self.line("store i8* %slab, i8** @mutex_slab");
+        // Allocate & initialize cond_slab and cond_mtx_slab
+        self.line(&format!("%cond_bytes = mul i64 {TAPE_LEN}, {MUTEX_STRIDE}"));
+        self.line("%cslab = call i8* @malloc(i64 %cond_bytes)");
+        self.line("store i8* %cslab, i8** @cond_slab");
+        self.line("%cmslab = call i8* @malloc(i64 %cond_bytes)");
+        self.line("store i8* %cmslab, i8** @cond_mtx_slab");
         // pthread_mutex_init for every cell
         self.line("%i = alloca i64");
         self.line("store i64 0, i64* %i");
@@ -162,10 +170,16 @@ impl Codegen {
         self.line(&format!("%cond = icmp slt i64 %cur, {TAPE_LEN}"));
         self.line("br i1 %cond, label %init.body, label %init.end");
         self.label("init.body");
-        self.line("%sl0 = load i8*, i8** @mutex_slab");
         self.line(&format!("%off = mul i64 %cur, {MUTEX_STRIDE}"));
+        self.line("%sl0 = load i8*, i8** @mutex_slab");
         self.line("%slot = getelementptr i8, i8* %sl0, i64 %off");
         self.line("call i32 @pthread_mutex_init(i8* %slot, i8* null)");
+        self.line("%cl0 = load i8*, i8** @cond_slab");
+        self.line("%cslot = getelementptr i8, i8* %cl0, i64 %off");
+        self.line("call i32 @pthread_cond_init(i8* %cslot, i8* null)");
+        self.line("%ml0 = load i8*, i8** @cond_mtx_slab");
+        self.line("%mslot2 = getelementptr i8, i8* %ml0, i64 %off");
+        self.line("call i32 @pthread_mutex_init(i8* %mslot2, i8* null)");
         self.line("%cur1 = add i64 %cur, 1");
         self.line("store i64 %cur1, i64* %i");
         self.line("br label %init.loop");

--- a/crates/engine/src/codegen/parallel.rs
+++ b/crates/engine/src/codegen/parallel.rs
@@ -125,6 +125,7 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
         g.line(&format!(
             "call i32 @pthread_join(i64 %tload{pid}_{i}, i8** null)"
         ));
+        g.line(&format!("call void @tsan_join(i64 %tload{pid}_{i})"));
     }
 }
 

--- a/crates/engine/src/codegen/parallel.rs
+++ b/crates/engine/src/codegen/parallel.rs
@@ -125,7 +125,9 @@ pub fn emit_parallel(g: &mut Codegen, parent_s: &str, branches: &[Vec<Node>]) {
         g.line(&format!(
             "call i32 @pthread_join(i64 %tload{pid}_{i}, i8** null)"
         ));
-        g.line(&format!("call void @tsan_join(i64 %tload{pid}_{i})"));
+        if g.sanitize {
+            g.line(&format!("call void @tsan_join(i64 %tload{pid}_{i})"));
+        }
     }
 }
 

--- a/crates/engine/src/interpreter.rs
+++ b/crates/engine/src/interpreter.rs
@@ -125,7 +125,7 @@ impl<R: RBound, W: WBound> ThreadState<R, W> {
                         panic!("LockRelease without matching LockAcquire");
                     }
                 }
-                Node::Wait(count) => {
+                Node::Sleep(count) => {
                     let dur = Duration::from_millis(100 * (*count as u64));
                     thread::sleep(dur);
                 }

--- a/crates/engine/src/interpreter.rs
+++ b/crates/engine/src/interpreter.rs
@@ -129,6 +129,7 @@ impl<R: RBound, W: WBound> ThreadState<R, W> {
                     let dur = Duration::from_millis(100 * (*count as u64));
                     thread::sleep(dur);
                 }
+                _ => continue, // TODO: Implement Wait and Notify
             }
         }
     }

--- a/crates/engine/src/lexer.rs
+++ b/crates/engine/src/lexer.rs
@@ -14,6 +14,8 @@ pub enum Token {
     LockStart,
     LockEnd,
     Sleep,
+    Wait,
+    Notify,
 }
 
 pub fn lex(input: &str) -> Vec<Token> {
@@ -36,6 +38,8 @@ pub fn lex(input: &str) -> Vec<Token> {
             '(' => tokens.push(Token::LockStart),
             ')' => tokens.push(Token::LockEnd),
             '~' => tokens.push(Token::Sleep),
+            '^' => tokens.push(Token::Wait),
+            'v' => tokens.push(Token::Notify),
             ';' => {
                 while chars.peek().is_some() && *chars.peek().unwrap() != '\n' {
                     chars.next();

--- a/crates/engine/src/lexer.rs
+++ b/crates/engine/src/lexer.rs
@@ -13,7 +13,7 @@ pub enum Token {
     ParEnd,
     LockStart,
     LockEnd,
-    Wait,
+    Sleep,
 }
 
 pub fn lex(input: &str) -> Vec<Token> {
@@ -35,7 +35,7 @@ pub fn lex(input: &str) -> Vec<Token> {
             '}' => tokens.push(Token::ParEnd),
             '(' => tokens.push(Token::LockStart),
             ')' => tokens.push(Token::LockEnd),
-            '~' => tokens.push(Token::Wait),
+            '~' => tokens.push(Token::Sleep),
             ';' => {
                 while chars.peek().is_some() && *chars.peek().unwrap() != '\n' {
                     chars.next();

--- a/crates/engine/src/parser.rs
+++ b/crates/engine/src/parser.rs
@@ -15,6 +15,8 @@ pub enum Node {
     LockAcquire,
     LockRelease,
     Sleep(usize),
+    Wait,
+    Notify,
 }
 
 fn parse_parallel(iter: &mut Peekable<Iter<Token>>) -> Vec<Vec<Node>> {
@@ -64,6 +66,8 @@ fn parse_nodes(iter: &mut Peekable<Iter<Token>>, terminators: &[Token]) -> Vec<N
                 }
                 nodes.push(Node::Sleep(count));
             }
+            Token::Wait => nodes.push(Node::Wait),
+            Token::Notify => nodes.push(Node::Notify),
             _ => break,
         }
     }

--- a/crates/engine/src/parser.rs
+++ b/crates/engine/src/parser.rs
@@ -14,7 +14,7 @@ pub enum Node {
     Parallel(Vec<Vec<Node>>),
     LockAcquire,
     LockRelease,
-    Wait(usize),
+    Sleep(usize),
 }
 
 fn parse_parallel(iter: &mut Peekable<Iter<Token>>) -> Vec<Vec<Node>> {
@@ -56,13 +56,13 @@ fn parse_nodes(iter: &mut Peekable<Iter<Token>>, terminators: &[Token]) -> Vec<N
             }
             Token::LockStart => nodes.push(Node::LockAcquire),
             Token::LockEnd => nodes.push(Node::LockRelease),
-            Token::Wait => {
+            Token::Sleep => {
                 let mut count = 1;
-                while let Some(&&Token::Wait) = iter.peek() {
+                while let Some(&&Token::Sleep) = iter.peek() {
                     count += 1;
                     iter.next();
                 }
-                nodes.push(Node::Wait(count));
+                nodes.push(Node::Sleep(count));
             }
             _ => break,
         }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -86,3 +86,18 @@ pub unsafe extern "C" fn tsan_join(child_tid: Tid) {
     let parent_tid = unsafe { libc::pthread_self() } as usize as Tid;
     vector_clock::vector_clock_join(parent_tid, child_tid);
 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_pre_wait(s: *const State) {
+    vector_clock::vector_clock_pre_wait(s);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_post_wait(s: *const State) {
+    vector_clock::vector_clock_post_wait(s);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_notify(s: *const State) {
+    vector_clock::vector_clock_notify(s);
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -83,6 +83,6 @@ pub unsafe extern "C" fn tsan_read(s: *const State) {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn tsan_post_parent_tid(parent_tid: u64) {
+pub unsafe extern "C" fn tsan_fork(parent_tid: u64) {
     let child_tid = unsafe { libc::pthread_self() } as usize as u64;
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::missing_safety_doc)]
 
-use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex};
+mod lockset;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -14,72 +13,14 @@ pub struct State {
     lock_cap: i64,
 }
 
-fn current_lockset(s: &State) -> HashSet<i64> {
-    let sp = s.lock_sp;
-    if sp <= 0 || s.lock_stack.is_null() {
-        return HashSet::new();
-    }
-    let src: &[i64] = unsafe { core::slice::from_raw_parts(s.lock_stack, sp as usize) };
-    src.iter().copied().collect()
-}
-
-struct Access {
-    tid: u64,
-    is_write: bool,
-    lockset: HashSet<i64>,
-}
-
-#[derive(Default)]
-struct CellHist {
-    last: Option<Access>,
-}
-
-static HIST: LazyLock<Mutex<HashMap<i64, CellHist>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
-
-unsafe fn tsan_access(s: *const State, is_write: bool) {
-    let s = unsafe { s.as_ref().expect("State pointer is null") };
-
-    let idx = s.ptr_index;
-    let cur_locks = current_lockset(s);
-    if cur_locks.contains(&idx) {
-        return;
-    }
-
-    let tid = unsafe { libc::pthread_self() } as usize as u64;
-    let mut map = HIST.lock().unwrap();
-    let entry = map.entry(idx).or_default();
-
-    if let Some(prev) = &entry.last
-        && prev.tid != tid
-        && prev.lockset.is_disjoint(&cur_locks)
-        && (is_write || prev.is_write)
-    {
-        eprintln!(
-            "[TSAN] race({}) cell={} prev{{tid:{}, write:{}}} now{{tid:{}, write:{}}}",
-            if is_write { "write" } else { "read" },
-            idx,
-            prev.tid,
-            prev.is_write,
-            tid,
-            is_write
-        );
-    }
-
-    entry.last = Some(Access {
-        tid,
-        is_write,
-        lockset: cur_locks,
-    });
-}
-
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_write(s: *const State) {
-    unsafe { tsan_access(s, true) };
+    unsafe { lockset::tsan_access(s, true) };
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_read(s: *const State) {
-    unsafe { tsan_access(s, false) };
+    unsafe { lockset::tsan_access(s, false) };
 }
 
 #[unsafe(no_mangle)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -2,11 +2,14 @@
 
 mod lockset;
 
+type Tid = u64;
+type Cell = i64;
+
 #[repr(C)]
 #[derive(Debug)]
 pub struct State {
     tape_base: *mut i8,
-    ptr_index: i64,
+    ptr_index: Cell,
     mutex_slab: *mut i8,
     lock_stack: *mut i64,
     lock_sp: i64,
@@ -24,15 +27,15 @@ pub unsafe extern "C" fn tsan_read(s: *const State) {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn tsan_fork(parent_tid: u64) {
-    let child_tid = unsafe { libc::pthread_self() } as usize as u64;
+pub unsafe extern "C" fn tsan_fork(parent_tid: Tid) {
+    let child_tid = unsafe { libc::pthread_self() } as usize as Tid;
 
     println!("[TSAN] fork: parent_tid={parent_tid}, child_tid={child_tid}");
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn tsan_join(child_tid: u64) {
-    let parent_tid = unsafe { libc::pthread_self() } as usize as u64;
+pub unsafe extern "C" fn tsan_join(child_tid: Tid) {
+    let parent_tid = unsafe { libc::pthread_self() } as usize as Tid;
 
     println!("[TSAN] join: parent_tid={parent_tid}, child_tid={child_tid}");
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -48,11 +48,9 @@ unsafe fn tsan_access(s: *const State, is_write: bool) {
     let tid = unsafe { libc::pthread_self() } as usize as u64;
     let mut map = HIST.lock().unwrap();
     let entry = map.entry(idx).or_default();
-    let tree = THREAD_TREE.lock().unwrap();
 
     if let Some(prev) = &entry.last
         && prev.tid != tid
-        && !tree.is_ancestor(prev.tid, tid)
         && prev.lockset.is_disjoint(&cur_locks)
         && (is_write || prev.is_write)
     {
@@ -84,43 +82,7 @@ pub unsafe extern "C" fn tsan_read(s: *const State) {
     unsafe { tsan_access(s, false) };
 }
 
-struct ThreadTree {
-    parent: HashMap<u64, u64>,
-}
-
-impl ThreadTree {
-    fn new() -> Self {
-        Self {
-            parent: HashMap::new(),
-        }
-    }
-
-    fn add_edge(&mut self, parent_id: u64, child_id: u64) {
-        self.parent.insert(child_id, parent_id);
-    }
-
-    fn is_descendant(&self, prev_id: u64, current_id: u64) -> bool {
-        let mut cur = current_id;
-        while let Some(&p) = self.parent.get(&cur) {
-            if p == prev_id {
-                return true;
-            }
-            cur = p;
-        }
-        false
-    }
-
-    fn is_ancestor(&self, id1: u64, id2: u64) -> bool {
-        self.is_descendant(id1, id2) || self.is_descendant(id2, id1)
-    }
-}
-
-static THREAD_TREE: LazyLock<Mutex<ThreadTree>> = LazyLock::new(|| Mutex::new(ThreadTree::new()));
-
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_post_parent_tid(parent_tid: u64) {
     let child_tid = unsafe { libc::pthread_self() } as usize as u64;
-
-    let mut tree = THREAD_TREE.lock().unwrap();
-    tree.add_edge(parent_tid, child_tid);
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -85,4 +85,13 @@ pub unsafe extern "C" fn tsan_read(s: *const State) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_fork(parent_tid: u64) {
     let child_tid = unsafe { libc::pthread_self() } as usize as u64;
+
+    println!("[TSAN] fork: parent_tid={parent_tid}, child_tid={child_tid}");
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_join(child_tid: u64) {
+    let parent_tid = unsafe { libc::pthread_self() } as usize as u64;
+
+    println!("[TSAN] join: parent_tid={parent_tid}, child_tid={child_tid}");
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,12 +15,12 @@ pub struct State {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_write(s: *const State) {
-    unsafe { lockset::tsan_access(s, true) };
+    unsafe { lockset::lockset_check(s, true) };
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_read(s: *const State) {
-    unsafe { lockset::tsan_access(s, false) };
+    unsafe { lockset::lockset_check(s, false) };
 }
 
 #[unsafe(no_mangle)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,9 +1,29 @@
 #![allow(clippy::missing_safety_doc)]
 
 mod lockset;
+mod vector_clock;
 
 type Tid = u64;
 type Cell = i64;
+
+const TAPE_LEN: usize = 30000;
+
+#[derive(Debug, Clone)]
+pub enum TsanError {
+    Race { cell: Cell, is_write: bool },
+}
+
+impl core::fmt::Display for TsanError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TsanError::Race { cell, is_write } => write!(
+                f,
+                "[TSAN] race({}) cell={cell}",
+                if *is_write { "write" } else { "read" }
+            ),
+        }
+    }
+}
 
 #[repr(C)]
 #[derive(Debug)]
@@ -16,26 +36,63 @@ pub struct State {
     lock_cap: i64,
 }
 
+fn report_if_both_race(lockset_res: Result<(), TsanError>, vc_res: Result<(), TsanError>) {
+    if let (
+        Err(TsanError::Race {
+            cell: c1,
+            is_write: w1,
+        }),
+        Err(TsanError::Race {
+            cell: c2,
+            is_write: w2,
+        }),
+    ) = (lockset_res, vc_res)
+        && c1 == c2
+    {
+        eprintln!(
+            "{}",
+            TsanError::Race {
+                cell: c1,
+                is_write: w1 || w2,
+            }
+        );
+    }
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_write(s: *const State) {
-    unsafe { lockset::lockset_check(s, true) };
+    report_if_both_race(
+        unsafe { lockset::lockset_check(s, true) },
+        vector_clock::vector_clock_write(s),
+    );
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_read(s: *const State) {
-    unsafe { lockset::lockset_check(s, false) };
+    report_if_both_race(
+        unsafe { lockset::lockset_check(s, false) },
+        vector_clock::vector_clock_read(s),
+    );
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_acquire(s: *const State, idx: Cell) {
+    vector_clock::vector_clock_acquire(s, idx);
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tsan_release(s: *const State, idx: Cell) {
+    vector_clock::vector_clock_release(s, idx);
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_fork(parent_tid: Tid) {
     let child_tid = unsafe { libc::pthread_self() } as usize as Tid;
-
-    println!("[TSAN] fork: parent_tid={parent_tid}, child_tid={child_tid}");
+    vector_clock::vector_clock_fork(parent_tid, child_tid);
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tsan_join(child_tid: Tid) {
     let parent_tid = unsafe { libc::pthread_self() } as usize as Tid;
-
-    println!("[TSAN] join: parent_tid={parent_tid}, child_tid={child_tid}");
+    vector_clock::vector_clock_join(parent_tid, child_tid);
 }

--- a/crates/runtime/src/lockset.rs
+++ b/crates/runtime/src/lockset.rs
@@ -1,0 +1,62 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::{LazyLock, Mutex};
+
+use crate::State;
+
+fn current_lockset(s: &State) -> HashSet<i64> {
+    let sp = s.lock_sp;
+    if sp <= 0 || s.lock_stack.is_null() {
+        return HashSet::new();
+    }
+    let src: &[i64] = unsafe { core::slice::from_raw_parts(s.lock_stack, sp as usize) };
+    src.iter().copied().collect()
+}
+
+struct Access {
+    tid: u64,
+    is_write: bool,
+    lockset: HashSet<i64>,
+}
+
+#[derive(Default)]
+struct CellHist {
+    last: Option<Access>,
+}
+
+static HIST: LazyLock<Mutex<HashMap<i64, CellHist>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub unsafe fn tsan_access(s: *const State, is_write: bool) {
+    let s = unsafe { s.as_ref().expect("State pointer is null") };
+
+    let idx = s.ptr_index;
+    let cur_locks = current_lockset(s);
+    if cur_locks.contains(&idx) {
+        return;
+    }
+
+    let tid = unsafe { libc::pthread_self() } as usize as u64;
+    let mut map = HIST.lock().unwrap();
+    let entry = map.entry(idx).or_default();
+
+    if let Some(prev) = &entry.last
+        && prev.tid != tid
+        && prev.lockset.is_disjoint(&cur_locks)
+        && (is_write || prev.is_write)
+    {
+        eprintln!(
+            "[TSAN] race({}) cell={} prev{{tid:{}, write:{}}} now{{tid:{}, write:{}}}",
+            if is_write { "write" } else { "read" },
+            idx,
+            prev.tid,
+            prev.is_write,
+            tid,
+            is_write
+        );
+    }
+
+    entry.last = Some(Access {
+        tid,
+        is_write,
+        lockset: cur_locks,
+    });
+}

--- a/crates/runtime/src/vector_clock.rs
+++ b/crates/runtime/src/vector_clock.rs
@@ -1,0 +1,160 @@
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
+
+use crate::{Cell, State, TAPE_LEN, Tid, TsanError};
+
+type VectorClock = HashMap<Tid, u64>;
+
+fn tick(c: &mut VectorClock, t: Tid) {
+    *c.entry(t).or_insert(0) += 1;
+}
+
+fn leq(a: &VectorClock, b: &VectorClock) -> bool {
+    for (k, av) in a {
+        if *av > *b.get(k).unwrap_or(&0) {
+            return false;
+        }
+    }
+    true
+}
+
+fn join_in(a: &mut VectorClock, b: &VectorClock) {
+    for (k, bv) in b {
+        let e = a.entry(*k).or_insert(0);
+        if *e < *bv {
+            *e = *bv;
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct RaceDetector {
+    ct: HashMap<Tid, VectorClock>,
+    rx: Vec<VectorClock>,
+    wx: Vec<VectorClock>,
+    lm: Vec<VectorClock>,
+}
+
+impl RaceDetector {
+    pub fn new() -> Self {
+        Self {
+            ct: HashMap::new(),
+            rx: vec![HashMap::new(); TAPE_LEN],
+            wx: vec![HashMap::new(); TAPE_LEN],
+            lm: vec![HashMap::new(); TAPE_LEN],
+        }
+    }
+
+    fn ct_mut(&mut self, t: Tid) -> &mut VectorClock {
+        self.ct.entry(t).or_default()
+    }
+
+    pub fn rel(&mut self, t: Tid, m: Cell) {
+        let ct = self.ct_mut(t);
+        tick(ct, t);
+        self.lm[m as usize] = ct.clone();
+    }
+
+    pub fn acq(&mut self, t: Tid, m: Cell) {
+        let lm = self.lm[m as usize].clone();
+        let ct = self.ct_mut(t);
+        join_in(ct, &lm);
+    }
+
+    pub fn rd(&mut self, t: Tid, x: Cell) -> Result<(), TsanError> {
+        let ct_snapshot = self.ct_mut(t).clone();
+        if !leq(&self.wx[x as usize], &ct_snapshot) {
+            return Err(TsanError::Race {
+                cell: x,
+                is_write: true,
+            });
+        }
+        let my_time = *ct_snapshot.get(&t).unwrap_or(&0);
+        self.rx[x as usize].insert(t, my_time);
+        Ok(())
+    }
+
+    pub fn wr(&mut self, t: Tid, x: Cell) -> Result<(), TsanError> {
+        let ct_snapshot = self.ct_mut(t).clone();
+        if !leq(&self.wx[x as usize], &ct_snapshot) {
+            return Err(TsanError::Race {
+                cell: x,
+                is_write: true,
+            });
+        }
+        if !leq(&self.rx[x as usize], &ct_snapshot) {
+            return Err(TsanError::Race {
+                cell: x,
+                is_write: false,
+            });
+        }
+        let my_time = *ct_snapshot.get(&t).unwrap_or(&0);
+        self.wx[x as usize].insert(t, my_time);
+        Ok(())
+    }
+
+    pub fn fork(&mut self, t: Tid, u: Tid) {
+        {
+            let ct_parent = self.ct_mut(t);
+            tick(ct_parent, t);
+        }
+        let mut cu = self.ct.get(&t).cloned().unwrap_or_default();
+        cu.remove(&u);
+        self.ct.insert(u, cu);
+        tick(self.ct_mut(u), u);
+    }
+
+    pub fn join(&mut self, t: Tid, u: Tid) {
+        let cu = self.ct.get(&u).cloned().unwrap_or_default();
+        let ct = self.ct_mut(t);
+        join_in(ct, &cu);
+        tick(ct, t);
+    }
+}
+
+static VECTOR_CLOCK: LazyLock<Mutex<RaceDetector>> =
+    LazyLock::new(|| Mutex::new(RaceDetector::new()));
+
+pub fn vector_clock_write(s: *const State) -> Result<(), TsanError> {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+    let tid = unsafe { libc::pthread_self() } as usize as Tid;
+    let s = unsafe { s.as_ref().expect("State pointer is null") };
+
+    vector_clock.wr(tid, s.ptr_index)
+}
+
+pub fn vector_clock_read(s: *const State) -> Result<(), TsanError> {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+    let tid = unsafe { libc::pthread_self() } as usize as Tid;
+    let s = unsafe { s.as_ref().expect("State pointer is null") };
+
+    vector_clock.rd(tid, s.ptr_index)
+}
+
+pub fn vector_clock_acquire(_: *const State, m: Cell) {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+    let tid = unsafe { libc::pthread_self() } as usize as Tid;
+
+    vector_clock.acq(tid, m);
+}
+
+pub fn vector_clock_release(_: *const State, m: Cell) {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+    let tid = unsafe { libc::pthread_self() } as usize as Tid;
+
+    vector_clock.rel(tid, m);
+}
+
+pub fn vector_clock_fork(parent_tid: Tid, child_tid: Tid) {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+
+    vector_clock.fork(parent_tid, child_tid);
+}
+
+pub fn vector_clock_join(parent_tid: Tid, child_tid: Tid) {
+    let mut vector_clock = VECTOR_CLOCK.lock().unwrap();
+
+    vector_clock.join(parent_tid, child_tid);
+}


### PR DESCRIPTION
## Summary

- Brainfork コンパイラ: wait (`^`) と notify (`v`) の文法を追加
- Thread Sanitizer: Vector Clock によるレースの検出に対応

### 追加文法について

- `^`: 現在指しているセルで Wait する
- `v`: 現在指しているセルで Wait している全てのスレッドを再開する

### Vector Clock

以下を参考にした。

https://uchan.hateblo.jp/entry/2020/05/12/185631

ただし、実際には `Vec` ではなく `HashMap` で実装した (スレッドの数が動的に増減するため)。
